### PR TITLE
don't ignore composer.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 vendor/
-composer.lock


### PR DESCRIPTION
Ignoring the composer.lock file is considered a bad practice because it forces us to do a 'composer update' every time we add a new dependency instead of the proper 'composer install'

related: https://blog.engineyard.com/2014/composer-its-all-about-the-lock-file