### PR TITLE
dirty quick fix for unicode search texts

### DIFF
--- a/gen/controller.php
+++ b/gen/controller.php
@@ -59,7 +59,7 @@ __TABLECOLUMNS_ARRAY__
             $whereClause =  $whereClause . " OR"; 
         }
         
-        $whereClause =  $whereClause . " " . $col . " LIKE '%". $searchValue ."%'";
+        $whereClause =  $whereClause . " " . $col . " LIKE BINARY '%". $searchValue ."%'";
         
         $i = $i + 1;
     }


### PR DESCRIPTION
To fix mysql error <Illegal mix of collations for operation 'like'> after typing in unicode search texts (such as Chinese characters)

Heres a dirty fix by assuming:

1. Those who seek the power of crud-admin-generator do not always know how to fiddle with charsets and collations, and they do not know what to expect.
2. Case insensitive search is not too useful in this case.
3. Performance is not an issue.

caveat: i have not tested the fix against mysql 5.5 minus