### PR TITLE
Match name for foreigner key even with prefix

### DIFF
--- a/src/app.php
+++ b/src/app.php
@@ -11,41 +11,41 @@
  */
 
 class queryData {
-    public $start;
-    public $recordsTotal;
-    public $recordsFiltered;
-    public $data;
+	public $start;
+	public $recordsTotal;
+	public $recordsFiltered;
+	public $data;
 
-    function queryData() {
-    }
+	function queryData() {
+	}
 }
- 
+
 use Silex\Application;
 
 $app = new Application();
 
 $app->register(new Silex\Provider\TwigServiceProvider(), array(
-    'twig.path' => __DIR__.'/../web/views',
+	'twig.path' => __DIR__.'/../web/views',
 ));
 $app->register(new Silex\Provider\FormServiceProvider());
 $app->register(new Silex\Provider\TranslationServiceProvider(), array(
-    'translator.messages' => array(),
+	'translator.messages' => array(),
 ));
 $app->register(new Silex\Provider\ValidatorServiceProvider());
 $app->register(new Silex\Provider\UrlGeneratorServiceProvider());
 $app->register(new Silex\Provider\SessionServiceProvider());
 $app->register(new Silex\Provider\DoctrineServiceProvider(), array(
 
-        'dbs.options' => array(
-            'db' => array(
-                'driver'   => 'pdo_mysql',
-                'dbname'   => 'DATABASE_NAME',
-                'host'     => '127.0.0.1',
-                'user'     => 'DATABASE_USER',
-                'password' => 'DATABASE_PASS',
-                'charset'  => 'utf8',
-            ),
-        )
+		'dbs.options' => array(
+			'db' => array(
+				'driver'   => 'pdo_mysql',
+				'dbname'   => 'DATABASE_NAME',
+				'host'     => '127.0.0.1',
+				'user'     => 'DATABASE_USER',
+				'password' => 'DATABASE_PASS',
+				'charset'  => 'utf8',
+			),
+		)
 ));
 
 $app['asset_path'] = '/resources';

--- a/src/app.php
+++ b/src/app.php
@@ -50,5 +50,8 @@ $app->register(new Silex\Provider\DoctrineServiceProvider(), array(
 
 $app['asset_path'] = '/resources';
 $app['debug'] = true;
+	// array of REGEX column name to display for foreigner key insted of ID
+	// default used :'name','title','e?mail','username'
+$app['usr_search_names_foreigner_key'] = array();
 
 return $app;

--- a/src/console.php
+++ b/src/console.php
@@ -20,101 +20,101 @@ use Doctrine\DBAL\Schema\Table;
 $console = new Application('CRUD Admin Generator command instalation', '1.0');
 
 $console
-    ->register('generate:admin')
-    ->setDefinition(array())
-    ->setDescription("Generate administrator")
-    ->setCode(function (InputInterface $input, OutputInterface $output) use ($app) {
+	->register('generate:admin')
+	->setDefinition(array())
+	->setDescription("Generate administrator")
+	->setCode(function (InputInterface $input, OutputInterface $output) use ($app) {
 
-	    $getTablesQuery = "SHOW TABLES";
-	    $getTablesResult = $app['db']->fetchAll($getTablesQuery, array());  	
+		$getTablesQuery = "SHOW TABLES";
+		$getTablesResult = $app['db']->fetchAll($getTablesQuery, array());
 
-	    $_dbTables = array();
-	    $dbTables = array();
+		$_dbTables = array();
+		$dbTables = array();
 
-	    foreach($getTablesResult as $getTableResult){
+		foreach($getTablesResult as $getTableResult){
 
 			$_dbTables[] = reset($getTableResult);
 
-	    	$dbTables[] = array(
-	    		"name" => reset($getTableResult), 
-	    		"columns" => array()
-	    	);
-	    }
+			$dbTables[] = array(
+				"name" => reset($getTableResult),
+				"columns" => array()
+			);
+		}
 
-    	foreach($dbTables as $dbTableKey => $dbTable){
-		    $getTableColumnsQuery = "SHOW COLUMNS FROM `" . $dbTable['name'] . "`";
-		    $getTableColumnsResult = $app['db']->fetchAll($getTableColumnsQuery, array());    
+		foreach($dbTables as $dbTableKey => $dbTable){
+			$getTableColumnsQuery = "SHOW COLUMNS FROM `" . $dbTable['name'] . "`";
+			$getTableColumnsResult = $app['db']->fetchAll($getTableColumnsQuery, array());
 
-		    foreach($getTableColumnsResult as $getTableColumnResult){
-		    	$dbTables[$dbTableKey]['columns'][] = $getTableColumnResult;
-		    }
+			foreach($getTableColumnsResult as $getTableColumnResult){
+				$dbTables[$dbTableKey]['columns'][] = $getTableColumnResult;
+			}
 
-    	}
+		}
 
 		$tables = array();
-    	foreach($dbTables as $dbTable){
+		foreach($dbTables as $dbTable){
 
-    		if(count($dbTable['columns']) <= 1){
-    			continue;
-    		}
+			if(count($dbTable['columns']) <= 1){
+				continue;
+			}
 
-    		$table_name = $dbTable['name'];
-    		$table_columns = array();
-    		$primary_key = false;
+			$table_name = $dbTable['name'];
+			$table_columns = array();
+			$primary_key = false;
 
-    		$primary_keys = 0;
-    		$primary_keys_auto = 0;
-    		foreach($dbTable['columns'] as $column){
-    			if($column['Key'] == "PRI"){
-    				$primary_keys++;
-    			}    			
-    			if($column['Extra'] == "auto_increment"){
-    				$primary_keys_auto++;
-    			}    			
-    		}
+			$primary_keys = 0;
+			$primary_keys_auto = 0;
+			foreach($dbTable['columns'] as $column){
+				if($column['Key'] == "PRI"){
+					$primary_keys++;
+				}
+				if($column['Extra'] == "auto_increment"){
+					$primary_keys_auto++;
+				}
+			}
 
-    		if($primary_keys === 1 || ($primary_keys > 1 && $primary_keys_auto === 1)){
+			if($primary_keys === 1 || ($primary_keys > 1 && $primary_keys_auto === 1)){
 
-	    		foreach($dbTable['columns'] as $column){
+				foreach($dbTable['columns'] as $column){
 
-	    			$external_table = false;
+					$external_table = false;
 
-	    			if($primary_keys > 1 && $primary_keys_auto == 1){
-		    			if($column['Extra'] == "auto_increment"){
-		    				$primary_key = $column['Field'];
-		    			}
-	    			}
-	    			else if($primary_keys == 1){
-		    			if($column['Key'] == "PRI"){
-		    				$primary_key = $column['Field'];
-		    			}
-		    		}
-		    		else{
-		    			continue 2;
-		    		}
-
-					if(substr($column['Field'], -3) == "_id"){
-					    $_table_name = substr($column['Field'], 0, -3);
-
-					    if(in_array($_table_name, $_dbTables)){
-					        $external_table = $_table_name;
-					    }
+					if($primary_keys > 1 && $primary_keys_auto == 1){
+						if($column['Extra'] == "auto_increment"){
+							$primary_key = $column['Field'];
+						}
+					}
+					else if($primary_keys == 1){
+						if($column['Key'] == "PRI"){
+							$primary_key = $column['Field'];
+						}
+					}
+					else{
+						continue 2;
 					}
 
-	    			$table_columns[] = array(
-	    				"name" => $column['Field'],
-	    				"primary" => $column['Field'] == $primary_key ? true : false,
-	    				"nullable" => $column['Null'] == "NO" ? true : false,
-	    				"auto" => $column['Extra'] == "auto_increment" ? true : false,
-	    				"external" => $column['Field'] != $primary_key ? $external_table : false,
-	    				"type" => $column['Type']
-	    			);
-	    		}
+					if(substr($column['Field'], -3) == "_id"){
+						$_table_name = substr($column['Field'], 0, -3);
 
-    		}
-    		else{
-    			continue;
-    		}
+						if(in_array($_table_name, $_dbTables)){
+							$external_table = $_table_name;
+						}
+					}
+
+					$table_columns[] = array(
+						"name" => $column['Field'],
+						"primary" => $column['Field'] == $primary_key ? true : false,
+						"nullable" => $column['Null'] == "NO" ? true : false,
+						"auto" => $column['Extra'] == "auto_increment" ? true : false,
+						"external" => $column['Field'] != $primary_key ? $external_table : false,
+						"type" => $column['Type']
+					);
+				}
+
+			}
+			else{
+				continue;
+			}
 
 
 			$tables[$table_name] = array(
@@ -122,10 +122,10 @@ $console
 				"columns" => $table_columns
 			);
 
-    	}
+		}
 
-    	$MENU_OPTIONS = "";
-    	$BASE_INCLUDES = "";
+		$MENU_OPTIONS = "";
+		$BASE_INCLUDES = "";
 
 		foreach($tables as $table_name => $table){
 
@@ -149,17 +149,17 @@ $console
 
 			$EDIT_FORM_TEMPLATE = "";
 
-			$MENU_OPTIONS .= "" . 
-			"<li class=\"treeview {% if option is defined and (option == '" . $TABLENAME . "_list' or option == '" . $TABLENAME . "_create' or option == '" . $TABLENAME . "_edit') %}active{% endif %}\">" . "\n" . 
-			"    <a href=\"#\">" . "\n" . 
-			"        <i class=\"fa fa-folder-o\"></i>" . "\n" . 
-			"        <span>" . $TABLENAME . "</span>" . "\n" . 
-			"        <i class=\"fa pull-right fa-angle-right\"></i>" . "\n" . 
-			"    </a>" . "\n" . 
-			"    <ul class=\"treeview-menu\" style=\"display: none;\">" . "\n" . 
-			"        <li {% if option is defined and option == '" . $TABLENAME . "_list' %}class=\"active\"{% endif %}><a href=\"{{ path('" . $TABLENAME . "_list') }}\" style=\"margin-left: 10px;\"><i class=\"fa fa-angle-double-right\"></i> List</a></li>" . "\n" . 
-			"        <li {% if option is defined and option == '" . $TABLENAME . "_create' %}class=\"active\"{% endif %}><a href=\"{{ path('" . $TABLENAME . "_create') }}\" style=\"margin-left: 10px;\"><i class=\"fa fa-angle-double-right\"></i> Create</a></li>" . "\n" . 
-			"    </ul>" . "\n" . 
+			$MENU_OPTIONS .= "" .
+			"<li class=\"treeview {% if option is defined and (option == '" . $TABLENAME . "_list' or option == '" . $TABLENAME . "_create' or option == '" . $TABLENAME . "_edit') %}active{% endif %}\">" . "\n" .
+			"    <a href=\"#\">" . "\n" .
+			"        <i class=\"fa fa-folder-o\"></i>" . "\n" .
+			"        <span>" . $TABLENAME . "</span>" . "\n" .
+			"        <i class=\"fa pull-right fa-angle-right\"></i>" . "\n" .
+			"    </a>" . "\n" .
+			"    <ul class=\"treeview-menu\" style=\"display: none;\">" . "\n" .
+			"        <li {% if option is defined and option == '" . $TABLENAME . "_list' %}class=\"active\"{% endif %}><a href=\"{{ path('" . $TABLENAME . "_list') }}\" style=\"margin-left: 10px;\"><i class=\"fa fa-angle-double-right\"></i> List</a></li>" . "\n" .
+			"        <li {% if option is defined and option == '" . $TABLENAME . "_create' %}class=\"active\"{% endif %}><a href=\"{{ path('" . $TABLENAME . "_create') }}\" style=\"margin-left: 10px;\"><i class=\"fa fa-angle-double-right\"></i> Create</a></li>" . "\n" .
+			"    </ul>" . "\n" .
 			"</li>" . "\n\n";
 
 			$BASE_INCLUDES .= "require_once __DIR__.'/" . $TABLENAME . "/index.php';" . "\n";
@@ -177,21 +177,21 @@ $console
 					$UPDATE_EXECUTE_FIELDS[] = "\$data['" . $table_column['name'] . "']";
 
 					if(strpos($table_column['type'], 'text') !== false){
-						$EDIT_FORM_TEMPLATE .= "" . 
-	                    "\t\t\t\t\t\t\t\t\t" . "<div class='form-group'>" . "\n" . 
-	                    "\t\t\t\t\t\t\t\t\t" . "    {{ form_label(form." . $table_column['name'] . ") }}" . "\n" . 
-	                    "\t\t\t\t\t\t\t\t\t" . "    {{ form_widget(form." . $table_column['name'] . ", { attr: { 'class': 'form-control textarea', 'style': 'width: 100%; height: 200px; font-size: 14px; line-height: 18px; border: 1px solid #dddddd; padding: 10px;' }}) }}" . "\n" . 
-	                    "\t\t\t\t\t\t\t\t\t" . "</div>" . "\n\n";
+						$EDIT_FORM_TEMPLATE .= "" .
+						"\t\t\t\t\t\t\t\t\t" . "<div class='form-group'>" . "\n" .
+						"\t\t\t\t\t\t\t\t\t" . "    {{ form_label(form." . $table_column['name'] . ") }}" . "\n" .
+						"\t\t\t\t\t\t\t\t\t" . "    {{ form_widget(form." . $table_column['name'] . ", { attr: { 'class': 'form-control textarea', 'style': 'width: 100%; height: 200px; font-size: 14px; line-height: 18px; border: 1px solid #dddddd; padding: 10px;' }}) }}" . "\n" .
+						"\t\t\t\t\t\t\t\t\t" . "</div>" . "\n\n";
 					}
 					else {
-						$EDIT_FORM_TEMPLATE .= "" . 
-	                    "\t\t\t\t\t\t\t\t\t" . "<div class='form-group'>" . "\n" . 
-	                    "\t\t\t\t\t\t\t\t\t" . "    {{ form_label(form." . $table_column['name'] . ") }}" . "\n" . 
-	                    "\t\t\t\t\t\t\t\t\t" . "    {{ form_widget(form." . $table_column['name'] . ", { attr: { 'class': 'form-control' }}) }}" . "\n" . 
-	                    "\t\t\t\t\t\t\t\t\t" . "</div>" . "\n\n";
-                	}
+						$EDIT_FORM_TEMPLATE .= "" .
+						"\t\t\t\t\t\t\t\t\t" . "<div class='form-group'>" . "\n" .
+						"\t\t\t\t\t\t\t\t\t" . "    {{ form_label(form." . $table_column['name'] . ") }}" . "\n" .
+						"\t\t\t\t\t\t\t\t\t" . "    {{ form_widget(form." . $table_column['name'] . ", { attr: { 'class': 'form-control' }}) }}" . "\n" .
+						"\t\t\t\t\t\t\t\t\t" . "</div>" . "\n\n";
+					}
 				}
-				
+
 				$field_nullable = $table_column['nullable'] ? "true" : "false";
 
 				if($table_column['external']){
@@ -201,78 +201,78 @@ $console
 					$external_select_field = false;
 
 					foreach($external_table['columns'] as $external_column){
-						if($external_column['name'] == "name" || 
-							$external_column['name'] == "title" || 
-							$external_column['name'] == "email" || 
+						if($external_column['name'] == "name" ||
+							$external_column['name'] == "title" ||
+							$external_column['name'] == "email" ||
 							$external_column['name'] == "username"){
-							$external_select_field = $external_column['name'];	
+							$external_select_field = $external_column['name'];
 						}
 					}
 
 					if(!$external_select_field){
 						$external_select_field = $external_primary_key;
 					}
-					
+
 					$external_cond = $count_externals > 0 ? "else if" : "if";
 
-					$EXTERNALS_FOR_LIST .= "" . 
-		            "\t\t\t" . $external_cond . "(\$table_columns[\$i] == '" . $table_column['name'] . "'){" . "\n" . 
-		            "\t\t\t" . "    \$findexternal_sql = 'SELECT `" . $external_select_field . "` FROM `" . $table_column['external'] . "` WHERE `" . $external_primary_key . "` = ?';" . "\n" . 
-		            "\t\t\t" . "    \$findexternal_row = \$app['db']->fetchAssoc(\$findexternal_sql, array(\$row_sql[\$table_columns[\$i]]));" . "\n" . 
-		            "\t\t\t" . "    \$rows[\$row_key][\$table_columns[\$i]] = \$findexternal_row['" . $external_select_field . "'];" . "\n" . 
-		            "\t\t\t" . "}" . "\n";
+					$EXTERNALS_FOR_LIST .= "" .
+					"\t\t\t" . $external_cond . "(\$table_columns[\$i] == '" . $table_column['name'] . "'){" . "\n" .
+					"\t\t\t" . "    \$findexternal_sql = 'SELECT `" . $external_select_field . "` FROM `" . $table_column['external'] . "` WHERE `" . $external_primary_key . "` = ?';" . "\n" .
+					"\t\t\t" . "    \$findexternal_row = \$app['db']->fetchAssoc(\$findexternal_sql, array(\$row_sql[\$table_columns[\$i]]));" . "\n" .
+					"\t\t\t" . "    \$rows[\$row_key][\$table_columns[\$i]] = \$findexternal_row['" . $external_select_field . "'];" . "\n" .
+					"\t\t\t" . "}" . "\n";
 
 
-		            $EXTERNALSFIELDS_FOR_FORM .= "" . 
-				    "\t" . "\$options = array();" . "\n" . 
-				    "\t" . "\$findexternal_sql = 'SELECT `" . $external_primary_key . "`, `" . $external_select_field . "` FROM `" . $table_column['external'] . "`';" . "\n" . 
-				    "\t" . "\$findexternal_rows = \$app['db']->fetchAll(\$findexternal_sql, array());" . "\n" . 
-				    "\t" . "foreach(\$findexternal_rows as \$findexternal_row){" . "\n" . 
-				    "\t" . "    \$options[\$findexternal_row['" . $external_primary_key . "']] = \$findexternal_row['" . $external_select_field . "'];" . "\n" . 
-				    "\t" . "}" . "\n" . 
-				    "\t" . "if(count(\$options) > 0){" . "\n" . 
-				    "\t" . "    \$form = \$form->add('" . $table_column['name'] . "', 'choice', array(" . "\n" . 
-				    "\t" . "        'required' => " . $field_nullable . "," . "\n" . 
-				    "\t" . "        'choices' => \$options," . "\n" . 
-				    "\t" . "        'expanded' => false," . "\n" . 
-				    "\t" . "        'constraints' => new Assert\Choice(array_keys(\$options))" . "\n" . 
-				    "\t" . "    ));" . "\n" . 
-				    "\t" . "}" . "\n" . 
-				    "\t" . "else{" . "\n" . 
-				    "\t" . "    \$form = \$form->add('" . $table_column['name'] . "', 'text', array('required' => " . $field_nullable . "));" . "\n" . 
-				    "\t" . "}" . "\n\n";
+					$EXTERNALSFIELDS_FOR_FORM .= "" .
+					"\t" . "\$options = array();" . "\n" .
+					"\t" . "\$findexternal_sql = 'SELECT `" . $external_primary_key . "`, `" . $external_select_field . "` FROM `" . $table_column['external'] . "`';" . "\n" .
+					"\t" . "\$findexternal_rows = \$app['db']->fetchAll(\$findexternal_sql, array());" . "\n" .
+					"\t" . "foreach(\$findexternal_rows as \$findexternal_row){" . "\n" .
+					"\t" . "    \$options[\$findexternal_row['" . $external_primary_key . "']] = \$findexternal_row['" . $external_select_field . "'];" . "\n" .
+					"\t" . "}" . "\n" .
+					"\t" . "if(count(\$options) > 0){" . "\n" .
+					"\t" . "    \$form = \$form->add('" . $table_column['name'] . "', 'choice', array(" . "\n" .
+					"\t" . "        'required' => " . $field_nullable . "," . "\n" .
+					"\t" . "        'choices' => \$options," . "\n" .
+					"\t" . "        'expanded' => false," . "\n" .
+					"\t" . "        'constraints' => new Assert\Choice(array_keys(\$options))" . "\n" .
+					"\t" . "    ));" . "\n" .
+					"\t" . "}" . "\n" .
+					"\t" . "else{" . "\n" .
+					"\t" . "    \$form = \$form->add('" . $table_column['name'] . "', 'text', array('required' => " . $field_nullable . "));" . "\n" .
+					"\t" . "}" . "\n\n";
 
-		            $count_externals++;
+					$count_externals++;
 				}
 				else{
 					if(!$table_column['primary']){
 
 						if(strpos($table_column['type'], 'text') !== false){
-							$FIELDS_FOR_FORM .= "" . 
-						    "\t" . "\$form = \$form->add('" . $table_column['name'] . "', 'textarea', array('required' => " . $field_nullable . "));" . "\n";
+							$FIELDS_FOR_FORM .= "" .
+							"\t" . "\$form = \$form->add('" . $table_column['name'] . "', 'textarea', array('required' => " . $field_nullable . "));" . "\n";
 						}
 						else{
-							$FIELDS_FOR_FORM .= "" . 
-						    "\t" . "\$form = \$form->add('" . $table_column['name'] . "', 'text', array('required' => " . $field_nullable . "));" . "\n";
+							$FIELDS_FOR_FORM .= "" .
+							"\t" . "\$form = \$form->add('" . $table_column['name'] . "', 'text', array('required' => " . $field_nullable . "));" . "\n";
 						}
 					}
 					else if($table_column['primary'] && !$table_column['auto']){
-							$FIELDS_FOR_FORM .= "" . 
-						    "\t" . "\$form = \$form->add('" . $table_column['name'] . "', 'text', array('required' => " . $field_nullable . "));" . "\n";
+							$FIELDS_FOR_FORM .= "" .
+							"\t" . "\$form = \$form->add('" . $table_column['name'] . "', 'text', array('required' => " . $field_nullable . "));" . "\n";
 					}
 				}
 			}
 
 			if($count_externals > 0){
-				$EXTERNALS_FOR_LIST .= "" . 
-	            "\t\t\t" . "else{" . "\n" . 
-	            "\t\t\t" . "    \$rows[\$row_key][\$table_columns[\$i]] = \$row_sql[\$table_columns[\$i]];" . "\n" . 
-	            "\t\t\t" . "}" . "\n";
+				$EXTERNALS_FOR_LIST .= "" .
+				"\t\t\t" . "else{" . "\n" .
+				"\t\t\t" . "    \$rows[\$row_key][\$table_columns[\$i]] = \$row_sql[\$table_columns[\$i]];" . "\n" .
+				"\t\t\t" . "}" . "\n";
 			}
-			
+
 			if($EXTERNALS_FOR_LIST == ""){
-				$EXTERNALS_FOR_LIST .= "" . 
-	            "\t\t" . "\$rows[\$row_key][\$table_columns[\$i]] = \$row_sql[\$table_columns[\$i]];" . "\n";
+				$EXTERNALS_FOR_LIST .= "" .
+				"\t\t" . "\$rows[\$row_key][\$table_columns[\$i]] = \$row_sql[\$table_columns[\$i]];" . "\n";
 			}
 
 
@@ -283,9 +283,9 @@ $console
 			$INSERT_QUERY_VALUES = implode(", ", $INSERT_QUERY_VALUES);
 			$INSERT_QUERY_FIELDS = implode(", ", $INSERT_QUERY_FIELDS);
 			$INSERT_EXECUTE_FIELDS = implode(", ", $INSERT_EXECUTE_FIELDS);
-			
+
 			$UPDATE_QUERY_FIELDS = implode(", ", $UPDATE_QUERY_FIELDS);
-			$UPDATE_EXECUTE_FIELDS = implode(", ", $UPDATE_EXECUTE_FIELDS);	
+			$UPDATE_EXECUTE_FIELDS = implode(", ", $UPDATE_EXECUTE_FIELDS);
 
 			$_controller = file_get_contents(__DIR__.'/../gen/controller.php');
 			$_controller = str_replace("__TABLENAME__", $TABLENAME, $_controller);
@@ -303,7 +303,7 @@ $console
 
 			$_controller = str_replace("__UPDATE_QUERY_FIELDS__", $UPDATE_QUERY_FIELDS, $_controller);
 			$_controller = str_replace("__UPDATE_EXECUTE_FIELDS__", $UPDATE_EXECUTE_FIELDS, $_controller);
-			
+
 
 			$_list_template = file_get_contents(__DIR__.'/../gen/list.html.twig');
 			$_list_template = str_replace("__TABLENAME__", $TABLENAME, $_list_template);
@@ -324,7 +324,7 @@ $console
 
 			$_base_file = file_get_contents(__DIR__.'/../gen/base.php');
 			$_base_file = str_replace("__BASE_INCLUDES__", $BASE_INCLUDES, $_base_file);
-			
+
 			@mkdir(__DIR__."/../web/controllers/".$TABLENAME, 0755);
 			@mkdir(__DIR__."/../web/views/".$TABLENAME, 0755);
 
@@ -346,11 +346,11 @@ $console
 
 			$fp = fopen(__DIR__."/../web/controllers/base.php", "w+");
 			fwrite($fp, $_base_file);
-			fclose($fp);		
+			fclose($fp);
 
 			$fp = fopen(__DIR__."/../web/views/menu.html.twig", "w+");
 			fwrite($fp, $_menu_template);
-			fclose($fp);	
+			fclose($fp);
 
 		}
 

--- a/src/console.php
+++ b/src/console.php
@@ -199,12 +199,19 @@ $console
 
 					$external_primary_key = $external_table['primary_key'];
 					$external_select_field = false;
+					$def_search_names_foreigner_key = array('name','title','e?mail','username');
+
+					if(!empty($app['usr_search_names_foreigner_key'])){
+						$search_names_foreigner_key = array_merge(
+							$app['usr_search_names_foreigner_key'],
+							$def_search_names_foreigner_key);
+					}
+
+						// pattern to match a name column, with or whitout a 3 to 4 Char prefix
+					$search_names_foreigner_key = '#^(.{3,4}_)?('.implode('|',$search_names_foreigner_key).')$#i';
 
 					foreach($external_table['columns'] as $external_column){
-						if($external_column['name'] == "name" ||
-							$external_column['name'] == "title" ||
-							$external_column['name'] == "email" ||
-							$external_column['name'] == "username"){
+						if( preg_match($search_names_foreigner_key, $external_column['name'])){
 							$external_select_field = $external_column['name'];
 						}
 					}


### PR DESCRIPTION
Feature : 
======= 
- switch to a `preg_match` finding method
- can take a none / {3}\_ / {4}\_ char prefix for the default :
    `'name','title','e?mail','username'`
- `$app['usr_search_names_foreigner_key']` allow you to add column to search pattern

eg : 
```SQL
SELECT id , frgn_name, frgn_foo, frgn_bar FROM foreigner ;
SELECT id , tab_name, foreigner_id FROM table ;
```
Will find the `foreigner.frgn_name` as a valid name for the foreigner key in `table`.

I've make a trim commit to keep my main clear.