### PR TITLE
Spaces to columns

### DIFF
--- a/gen/controller.php
+++ b/gen/controller.php
@@ -63,7 +63,7 @@ __TABLECOLUMNS_TYPE_ARRAY__
             $whereClause =  $whereClause . " OR"; 
         }
         
-        $whereClause =  $whereClause . " " . $col . " LIKE '%". $searchValue ."%'";
+        $whereClause =  $whereClause . " '" . $col . "' LIKE '%". $searchValue ."%'";
         
         $i = $i + 1;
     }

--- a/gen/controller.php
+++ b/gen/controller.php
@@ -63,7 +63,7 @@ __TABLECOLUMNS_TYPE_ARRAY__
             $whereClause =  $whereClause . " OR"; 
         }
         
-        $whereClause =  $whereClause . " '" . $col . "' LIKE '%". $searchValue ."%'";
+        $whereClause =  $whereClause . " `" . $col . "` LIKE '%". $searchValue ."%'";
         
         $i = $i + 1;
     }


### PR DESCRIPTION
Using ` instead of ' to surround col names