### PR TITLE
Escape column type name, example: 'enum('x', 'y')' => 'enum(\'x\', \'y\')'

### DIFF
--- a/src/console.php
+++ b/src/console.php
@@ -168,7 +168,7 @@ $console
 			$count_externals = 0;
 			foreach($table_columns as $table_column){
 				$TABLECOLUMNS_ARRAY .= "\t\t" . "'". $table_column['name'] . "', \n";
-				$TABLECOLUMNS_TYPE_ARRAY .= "\t\t" . "'". $table_column['type'] . "', \n";				
+				$TABLECOLUMNS_TYPE_ARRAY .= "\t\t" . "'". addslashes($table_column['type']) . "', \n";
 				if(!$table_column['primary'] || ($table_column['primary'] && !$table_column['auto'])){
 					$TABLECOLUMNS_INITIALDATA_EMPTY_ARRAY .= "\t\t" . "'". $table_column['name'] . "' => '', \n";
 					$TABLECOLUMNS_INITIALDATA_ARRAY .= "\t\t" . "'". $table_column['name'] . "' => \$row_sql['".$table_column['name']."'], \n";


### PR DESCRIPTION
For fix issue #68 
