### PR TITLE
changed jquery path to protocol relative url

### DIFF
--- a/web/views/ag_base/backend.html.twig
+++ b/web/views/ag_base/backend.html.twig
@@ -42,7 +42,7 @@
 
 {% block javascripts %}
     <!-- jQuery 2.0.2 -->
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.0.2/jquery.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/2.0.2/jquery.min.js"></script>
     <!-- jQuery UI 1.10.3 -->
     <script src="{{ app.asset_path }}/js/jquery-ui-1.10.3.min.js" type="text/javascript"></script>
     <!-- Bootstrap -->


### PR DESCRIPTION
The jquery path in backend.html.twig was using http protocol, so the generated page was not working over https. I have simply changed it to protocol relative url.