### PR TITLE
Quoting column names to prevent errors

### DIFF
--- a/gen/controller.php
+++ b/gen/controller.php
@@ -39,7 +39,7 @@ $app->match('/__TABLENAME__/list', function (Symfony\Component\HttpFoundation\Re
     
     $orderClause = "";
     if($orderValue) {
-        $orderClause = " ORDER BY ". $columns[(int)$orderValue['column']]['data'] . " " . $orderValue['dir'];
+        $orderClause = " ORDER BY `". $columns[(int)$orderValue['column']]['data'] . "` " . $orderValue['dir'];
     }
     
     $table_columns = array(
@@ -63,7 +63,7 @@ __TABLECOLUMNS_TYPE_ARRAY__
             $whereClause =  $whereClause . " OR"; 
         }
         
-        $whereClause =  $whereClause . " " . $col . " LIKE '%". $searchValue ."%'";
+        $whereClause =  $whereClause . " `" . $col . "` LIKE '%". $searchValue ."%'";
         
         $i = $i + 1;
     }


### PR DESCRIPTION
Quoting column names to prevent errors when columns names match reserved MySQL keywords