### PR TITLE
Adapt crud-admin-generator to work using PostgreSQL

### DIFF
--- a/gen/controller.php
+++ b/gen/controller.php
@@ -69,10 +69,10 @@ __TABLECOLUMNS_TYPE_ARRAY__
 
         $i = $i + 1;
     }
-    
-    $recordsTotal = $app['db']->fetchColumn("SELECT COUNT(*) FROM `__TABLENAME__`" . $whereClause . $orderClause, array(), 0);
-    
-    $find_sql = "SELECT * FROM `__TABLENAME__`". $whereClause . $orderClause . " LIMIT ". $index . "," . $rowsPerPage;
+
+    $recordsTotal = $app['db']->fetchColumn("SELECT COUNT(*) FROM __TABLENAME__" . $whereClause, array(), 0);
+
+    $find_sql = "SELECT * FROM __TABLENAME__". $whereClause . $orderClause . " OFFSET ". $index . " LIMIT " . $rowsPerPage;
     $rows_sql = $app['db']->fetchAll($find_sql, array());
 
     foreach($rows_sql as $row_key => $row_sql){

--- a/gen/controller.php
+++ b/gen/controller.php
@@ -64,9 +64,9 @@ __TABLECOLUMNS_TYPE_ARRAY__
         if ($i > 0) {
             $whereClause =  $whereClause . " OR"; 
         }
-        
-        $whereClause =  $whereClause . " " . $col . " LIKE '%". $searchValue ."%'";
-        
+
+        $whereClause =  $whereClause . " " . $col . "::varchar(255) LIKE '%". $searchValue ."%'";
+
         $i = $i + 1;
     }
     
@@ -172,8 +172,8 @@ __FIELDS_FOR_FORM__
         if ($form->isValid()) {
             $data = $form->getData();
 
-            $update_query = "INSERT INTO `__TABLENAME__` (__INSERT_QUERY_FIELDS__) VALUES (__INSERT_QUERY_VALUES__)";
-            $app['db']->executeUpdate($update_query, array(__INSERT_EXECUTE_FIELDS__));            
+            $update_query = "INSERT INTO __TABLENAME__ (__INSERT_QUERY_FIELDS__) VALUES (__INSERT_QUERY_VALUES__)";
+            $app['db']->executeUpdate($update_query, array(__INSERT_EXECUTE_FIELDS__));
 
 
             $app['session']->getFlashBag()->add(
@@ -198,7 +198,7 @@ __FIELDS_FOR_FORM__
 
 $app->match('/__TABLENAME__/edit/{id}', function ($id) use ($app) {
 
-    $find_sql = "SELECT * FROM `__TABLENAME__` WHERE `__TABLE_PRIMARYKEY__` = ?";
+    $find_sql = "SELECT * FROM __TABLENAME__ WHERE __TABLE_PRIMARYKEY__ = ?";
     $row_sql = $app['db']->fetchAssoc($find_sql, array($id));
 
     if(!$row_sql){
@@ -231,8 +231,8 @@ __FIELDS_FOR_FORM__
         if ($form->isValid()) {
             $data = $form->getData();
 
-            $update_query = "UPDATE `__TABLENAME__` SET __UPDATE_QUERY_FIELDS__ WHERE `__TABLE_PRIMARYKEY__` = ?";
-            $app['db']->executeUpdate($update_query, array(__UPDATE_EXECUTE_FIELDS__, $id));            
+            $update_query = "UPDATE __TABLENAME__ SET __UPDATE_QUERY_FIELDS__ WHERE __TABLE_PRIMARYKEY__ = ?";
+            $app['db']->executeUpdate($update_query, array(__UPDATE_EXECUTE_FIELDS__, $id));
 
 
             $app['session']->getFlashBag()->add(
@@ -250,18 +250,18 @@ __FIELDS_FOR_FORM__
         "form" => $form->createView(),
         "id" => $id
     ));
-        
+
 })
 ->bind('__TABLENAME___edit');
 
 
 $app->match('/__TABLENAME__/delete/{id}', function ($id) use ($app) {
 
-    $find_sql = "SELECT * FROM `__TABLENAME__` WHERE `__TABLE_PRIMARYKEY__` = ?";
+    $find_sql = "SELECT * FROM __TABLENAME__ WHERE __TABLE_PRIMARYKEY__ = ?";
     $row_sql = $app['db']->fetchAssoc($find_sql, array($id));
 
     if($row_sql){
-        $delete_query = "DELETE FROM `__TABLENAME__` WHERE `__TABLE_PRIMARYKEY__` = ?";
+        $delete_query = "DELETE FROM __TABLENAME__ WHERE __TABLE_PRIMARYKEY__ = ?";
         $app['db']->executeUpdate($delete_query, array($id));
 
         $app['session']->getFlashBag()->add(
@@ -305,13 +305,13 @@ __TABLECOLUMNS_TYPE_ARRAY__
         }
     }
 
-    $columns_to_select = implode(',', array_map(function ($row){
-        return '`'.$row.'`';
+    $columns_to_select = implode(', ', array_map(function ($row){
+        return $row;
     }, $table_columns));
-     
-    $find_sql = "SELECT ".$columns_to_select." FROM `__TABLENAME__`";
+
+    $find_sql = "SELECT ".$columns_to_select." FROM __TABLENAME__";
     $rows_sql = $app['db']->fetchAll($find_sql, array());
-  
+
     $mpdf = new mPDF();
 
     $stylesheet = file_get_contents('../web/resources/css/bootstrap.min.css'); // external css

--- a/src/app.php
+++ b/src/app.php
@@ -38,8 +38,8 @@ $app->register(new Silex\Provider\DoctrineServiceProvider(), array(
 
 		'dbs.options' => array(
 			'db' => array(
-				'driver'   => 'pdo_mysql',
 				'dbname'   => 'DATABASE_NAME',
+				'driver'   => 'pdo_pgsql',
 				'host'     => '127.0.0.1',
 				'user'     => 'DATABASE_USER',
 				'password' => 'DATABASE_PASS',

--- a/src/console.php
+++ b/src/console.php
@@ -48,7 +48,7 @@ $console
 			EOT;
 			$getTableColumnsQuery .= $dbTable['name'];
 			$getTableColumnsQuery .= <<<EOT
-			' AND NOT EXISTS (SELECT * FROM table_column_constraints other WHERE other.column_name=given.column_name AND given.constraint_type!='PRIMARY KEY' AND other.constraint_type='PRIMARY KEY') ORDER BY constraint_type;
+			' AND NOT EXISTS (SELECT * FROM table_column_constraints other WHERE other.column_name=given.column_name AND given.constraint_type!='PRIMARY KEY' AND other.constraint_type='PRIMARY KEY');
 			EOT;
 			$getTableColumnsResult = $app['db']->fetchAll($getTableColumnsQuery, array());
 


### PR DESCRIPTION
I don't know if someone will find this useful, but it seems possible because I needed it. This breaks support for MySQL and I'm not making an attempt to fix that, so please don't consider this an actual pull request as I don't want to break your library. Rather, I hope this helps someone. If you wanted to try to incorporate it, I think it could be manageable. Thanks for doing the work you did on this.

In order to query the columns from each table it was convenient for me to construct a VIEW to make the query a little shorter.  Here's how I defined that view:

> CREATE VIEW table_column_constraints as (SELECT c.table_schema, c.table_name, c.column_name
>            , c.data_type
>            , c.is_nullable
>            , tc.constraint_type              
>            , c.column_default 
>     FROM information_schema.columns AS c 
>     LEFT JOIN information_schema.constraint_column_usage AS ccu USING (column_name, table_name) 
>     LEFT JOIN information_schema.table_constraints tc ON tc.constraint_name=ccu.constraint_name WHERE c.table_schema='public');

NOTE: I haven't taken the time to get bulk downloads working. Not sure what is wrong. Everything else appears to be working as a baseline. There are also some ephemeral errors on update which I haven't fixed because they only flash on-screen before disappearing and the update succeeding.